### PR TITLE
created_at --> processed_at (for clients who transfer shopify accts)

### DIFF
--- a/models/base/shopify_orders.sql
+++ b/models/base/shopify_orders.sql
@@ -21,6 +21,7 @@
     "customer_id",
     "email",
     "created_at",
+    "processed_at",
     "updated_at",
     "cancelled_at",
     "financial_status",
@@ -256,7 +257,7 @@ WITH
     )
 
 SELECT *,
-    created_at::date as order_date, 
+    processed_at::date as order_date, 
     {{ get_date_parts('order_date') }},
     COALESCE(total_discounts/NULLIF(gross_revenue,0),0) as discount_rate,
     -- exclude cancelled orders vs Shopify includes cancelled orders

--- a/models/base/shopify_orders.sql
+++ b/models/base/shopify_orders.sql
@@ -263,7 +263,7 @@ SELECT *,
     -- exclude cancelled orders vs Shopify includes cancelled orders
     MIN(CASE WHEN cancelled_at IS NULL THEN order_date END) OVER (PARTITION BY customer_id) as customer_first_order_date,
     MAX(CASE WHEN cancelled_at IS NULL THEN order_date END) OVER (PARTITION BY customer_id) as customer_last_order_date, 
-    CASE WHEN cancelled_at IS NULL THEN ROW_NUMBER() OVER (PARTITION BY customer_id, cancelled_at IS NULL ORDER BY created_at) END as customer_order_index,
+    CASE WHEN cancelled_at IS NULL THEN ROW_NUMBER() OVER (PARTITION BY customer_id, cancelled_at IS NULL ORDER BY order_date) END as customer_order_index,
     order_id as unique_key
 FROM orders 
 LEFT JOIN discount USING(order_id)

--- a/models/base/shopify_transactions.sql
+++ b/models/base/shopify_transactions.sql
@@ -34,7 +34,7 @@ WITH raw_data AS
     transactions AS 
     (SELECT 
         order_id, 
-        created_at::date as transaction_date,
+        processed_at::date as transaction_date,
         COALESCE(SUM(CASE WHEN kind in ('sale','authorization') THEN transaction_amount END),0) as paid_by_customer,
         COALESCE(SUM(CASE WHEN kind = 'refund' THEN transaction_amount END),0) as refunded
     FROM staging

--- a/models/reporting/shopify_daily_sales_by_customer.sql
+++ b/models/reporting/shopify_daily_sales_by_customer.sql
@@ -16,11 +16,6 @@ WITH orders AS
     GROUP BY date, customer_id
     ),
 
-    customers AS 
-    (SELECT customer_id, customer_acquisition_date
-    FROM {{ ref('shopify_customers') }} 
-    ),
-
     sales AS 
     (SELECT *, 
         subtotal_sales - COALESCE(returns,0) as net_sales
@@ -28,6 +23,7 @@ WITH orders AS
         (SELECT 
             date, 
             customer_id, 
+            customer_acquisition_date,
             COUNT(order_id) as orders,
             COUNT(CASE WHEN customer_order_index = 1 THEN order_id END) as first_orders,
             COUNT(CASE WHEN customer_order_index > 1 THEN order_id END) as repeat_orders,
@@ -47,5 +43,4 @@ WITH orders AS
 
 SELECT *,
     date||'_'||customer_id as unique_key
-FROM sales 
-LEFT JOIN customers USING(customer_id)
+FROM sales

--- a/models/reporting/shopify_daily_sales_by_customer.sql
+++ b/models/reporting/shopify_daily_sales_by_customer.sql
@@ -23,7 +23,6 @@ WITH orders AS
         (SELECT 
             date, 
             customer_id, 
-            customer_acquisition_date,
             COUNT(order_id) as orders,
             COUNT(CASE WHEN customer_order_index = 1 THEN order_id END) as first_orders,
             COUNT(CASE WHEN customer_order_index > 1 THEN order_id END) as repeat_orders,

--- a/models/reporting/shopify_daily_sales_by_order.sql
+++ b/models/reporting/shopify_daily_sales_by_order.sql
@@ -26,6 +26,7 @@ WITH giftcard_deduction AS
     (SELECT 
         order_date as date,
         cancelled_at::date as cancelled_at,
+        customer_first_order_date as customer_acquisition_date,
         order_id, 
         customer_id, 
         customer_order_index,
@@ -45,15 +46,9 @@ WITH giftcard_deduction AS
     AND source_name NOT IN ({{ sales_channel_exclusion_list }})
     AND (order_tags !~* '{{ var("order_tags_keyword_exclusion")}}' OR order_tags IS NULL)
 
-    ),
-
-    customers AS 
-    (SELECT customer_id, customer_acquisition_date
-    FROM {{ ref('shopify_customers') }}
     )
 
 SELECT *,
     {{ get_date_parts('date') }},
     date||'_'||order_id as unique_key
 FROM orders 
-LEFT JOIN customers USING(customer_id)

--- a/models/reporting/shopify_daily_sales_by_order_line_item.sql
+++ b/models/reporting/shopify_daily_sales_by_order_line_item.sql
@@ -19,11 +19,6 @@ WITH orders AS
     (SELECT product_id, variant_id, product_type, product_tags
     FROM {{ ref('shopify_products') }}
     ),
-    
-    customers AS 
-    (SELECT customer_id, customer_acquisition_date
-    FROM {{ ref('shopify_customers') }}
-    ),
 
     sales AS 
     (SELECT 
@@ -57,4 +52,3 @@ SELECT *,
     date||'_'||order_line_id as unique_key
 FROM sales 
 LEFT JOIN products USING(product_id, variant_id)
-LEFT JOIN customers USING(customer_id)


### PR DESCRIPTION
**models/base/shopify_orders**
- i added processed_at into the order_selected_fields
- changed the order_date alias to pull from processed_at
- updated the customer_order_index to use order_date instead of created_at

**models/base/shopify_transactions**
- changed the transaction_date alias to pull from processed_at
- ignored macros/snippets/get_shopify_clean_field since the only item is created_at --> customer_acquisition_date in the customer table, and this doesn’t impact reporting level where we get customer_first_order_date from shopify_daily_sales_by_order

**models/reporting/shopify_daily_sales_by_order**
- added customer_acquisition_date (using customer_first_order_date) into the orders cte
- removed the customers cte & left join

**other reporting models (customer & line item)**
- removed the customers cte & left join